### PR TITLE
Add support for handling all events

### DIFF
--- a/src/kixi/comms.clj
+++ b/src/kixi/comms.clj
@@ -8,6 +8,7 @@
     [this command version payload]
     [this command version payload opts])
   (attach-event-handler!
+    [this group-id handler]
     [this group-id event version handler])
   (attach-command-handler!
     [this group-id event version handler]))

--- a/src/kixi/comms.clj
+++ b/src/kixi/comms.clj
@@ -8,7 +8,8 @@
     [this command version payload]
     [this command version payload opts])
   (attach-event-handler!
-    [this group-id handler]
     [this group-id event version handler])
+  (attach-event-with-key-handler!
+    [this group-id map-key handler])
   (attach-command-handler!
     [this group-id event version handler]))

--- a/src/kixi/comms/components/kafka.clj
+++ b/src/kixi/comms/components/kafka.clj
@@ -115,18 +115,23 @@
       (error e "Producer Exception"))))
 
 (defn process-msg?
-  [msg-type event version]
-  (fn [msg]
-    (when (and
-           (= (name msg-type)
+  ([msg-type]
+   (fn [msg]
+     (when (= (name msg-type)
               (:kixi.comms.message/type msg))
-           (= event
-              (or (:kixi.comms.command/key msg)
-                  (:kixi.comms.event/key msg)))
-           (= version
-              (or (:kixi.comms.command/version msg)
-                  (:kixi.comms.event/version msg))))
-      msg)))
+       msg)))
+  ([msg-type event version]
+   (fn [msg]
+     (when (and
+            (= (name msg-type)
+               (:kixi.comms.message/type msg))
+            (= event
+               (or (:kixi.comms.command/key msg)
+                   (:kixi.comms.event/key msg)))
+            (= version
+               (or (:kixi.comms.command/version msg)
+                   (:kixi.comms.event/version msg))))
+       msg))))
 
 (defn handle-result
   [kafka msg-type original result]
@@ -252,6 +257,19 @@
   (send-command! [{:keys [producer-in-ch]} command version payload opts]
     (when producer-in-ch
       (async/put! producer-in-ch [:command command version payload opts])))
+  (attach-event-handler! [this group-id handler]
+    (let [kill-chan (async/chan)
+          _ (async/tap consumer-kill-mult kill-chan)]
+      (->> (create-consumer (msg-handler-fn handler
+                                            (partial handle-result this :event))
+                            (process-msg? :event)
+                            kill-chan
+                            (build-consumer-config
+                             group-id
+                             (:event topics)
+                             broker-list
+                             (:consumer-config this)))
+           (swap! consumer-loops conj))))
   (attach-event-handler! [this group-id event version handler]
     (let [kill-chan (async/chan)
           _ (async/tap consumer-kill-mult kill-chan)]

--- a/test/kixi/comms/components/kafka_test.clj
+++ b/test/kixi/comms/components/kafka_test.clj
@@ -193,12 +193,15 @@
     (is (= :test/test-a (get-in @e-result [:kixi.comms.event/payload :kixi.comms.command/key])))
     (is (= (:kixi.comms.command/id @c-result) (:kixi.comms.command/id @e-result)))))
 
-(deftest roundtrip-command->event-open
+(deftest roundtrip-command->event-with-key
   (let [c-result (atom nil)
         e-result (atom nil)
         id (str (java.util.UUID/randomUUID))]
     (comms/attach-command-handler! (:kafka @system) :component-j :test/test-xyz "1.0.0" (partial reset-as-event! c-result))
-    (comms/attach-event-handler! (:kafka @system) :component-k (fn [x] (reset! e-result x) nil))
+    (comms/attach-event-with-key-handler! (:kafka @system)
+                                         :component-k
+                                         :kixi.comms.command/id
+                                         (fn [x] (reset! e-result x) nil))
     (comms/send-command! (:kafka @system) :test/test-xyz "1.0.0" {:foo "123" :id id})
     (wait-for-atom c-result)
     (wait-for-atom e-result)

--- a/test/kixi/comms/components/kafka_test.clj
+++ b/test/kixi/comms/components/kafka_test.clj
@@ -193,6 +193,22 @@
     (is (= :test/test-a (get-in @e-result [:kixi.comms.event/payload :kixi.comms.command/key])))
     (is (= (:kixi.comms.command/id @c-result) (:kixi.comms.command/id @e-result)))))
 
+(deftest roundtrip-command->event-open
+  (let [c-result (atom nil)
+        e-result (atom nil)
+        id (str (java.util.UUID/randomUUID))]
+    (comms/attach-command-handler! (:kafka @system) :component-j :test/test-xyz "1.0.0" (partial reset-as-event! c-result))
+    (comms/attach-event-handler! (:kafka @system) :component-k (fn [x] (reset! e-result x) nil))
+    (comms/send-command! (:kafka @system) :test/test-xyz "1.0.0" {:foo "123" :id id})
+    (wait-for-atom c-result)
+    (wait-for-atom e-result)
+    (is @c-result)
+    (is @e-result)
+    (is (= id (get-in @c-result [:kixi.comms.command/payload :id])))
+    (is (= id (get-in @e-result [:kixi.comms.event/payload :kixi.comms.command/payload :id])))
+    (is (= :test/test-xyz (get-in @e-result [:kixi.comms.event/payload :kixi.comms.command/key])))
+    (is (= (:kixi.comms.command/id @c-result) (:kixi.comms.command/id @e-result)))))
+
 (defn wait
   [ms]
   (Thread/sleep ms))


### PR DESCRIPTION
Add a new arity to `add-event-handler!` so that you do not need to specify an event key and version. Use sparingly.