### PR TITLE
Command ids used to select shard, multi events sequenced

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (def slf4j-version "1.7.21")
-(defproject kixi/kixi.comms "0.2.3"
+(defproject kixi/kixi.comms "0.2.4-SNAPSHOT"
   :description "FIXME: write description"
   :url "https://github.com/MastodonC/kixi.comms"
   :license {:name "Eclipse Public License"

--- a/src/kixi/comms/components/kinesis.clj
+++ b/src/kixi/comms/components/kinesis.clj
@@ -31,7 +31,7 @@
   [endpoint streams]
   (let [{:keys [stream-names]} (list-streams endpoint)
         missing-streams (remove (set stream-names) streams)
-        shards 1]
+        shards 3]
     (doseq [stream-name missing-streams]
       (info "Creating stream" stream-name "with" shards "shard(s)!")
       (kinesis/create-stream {:endpoint endpoint} stream-name shards))
@@ -126,16 +126,19 @@
   (async/go
     (loop []
       (let [msg (async/<! in-chan)]
-        (if msg
+        (when msg
           (let [[stream-name-key _ _ _ _ opts] msg
                 stream-name (get stream-names stream-name-key)
-                formatted (apply msg/format-message (conj (vec (butlast msg)) (assoc opts :origin origin)))]
+                formatted (apply msg/format-message (conj (vec (butlast msg)) (assoc opts :origin origin)))
+                seq-num (:kixi.comms.event/seq-num opts)
+                cmd-id (:kixi.comms.command/id opts)]
             (when comms/*verbose-logging*
               (info "Sending msg to Kinesis stream" stream-name ":" formatted))
             (kinesis/put-record {:endpoint endpoint}
                                 stream-name
                                 (msg/edn-to-bytebuffer formatted)
-                                (str (java.util.UUID/randomUUID)))
+                                (or cmd-id (str (java.util.UUID/randomUUID)))
+                                seq-num)
             (recur)))))))
 
 (defn attach-generic-processing-switch

--- a/src/kixi/comms/components/kinesis.clj
+++ b/src/kixi/comms/components/kinesis.clj
@@ -31,7 +31,7 @@
   [endpoint streams]
   (let [{:keys [stream-names]} (list-streams endpoint)
         missing-streams (remove (set stream-names) streams)
-        shards 3]
+        shards 2]
     (doseq [stream-name missing-streams]
       (info "Creating stream" stream-name "with" shards "shard(s)!")
       (kinesis/create-stream {:endpoint endpoint} stream-name shards))

--- a/src/kixi/comms/messages.clj
+++ b/src/kixi/comms/messages.clj
@@ -37,11 +37,13 @@
                               (s/explain-data ::ks/event-result result))))
       (letfn [(send-event-fn! [{:keys [kixi.comms.event/key
                                        kixi.comms.event/version
-                                       kixi.comms.event/payload] :as f}]
+                                       kixi.comms.event/payload
+                                       kixi.comms.event/seq-num] :as f}]
                 (comms/send-event! comms-component key version payload
-                                   {:command-id (:kixi.comms.command/id original)}))]
+                                   {:command-id (:kixi.comms.command/id original)
+                                    :seq-num seq-num}))]
         (if (sequential? result)
-          (run! send-event-fn! result)
+          (run! send-event-fn! (map-indexed #(assoc %2 :seq-num %1) result))
           (send-event-fn! result))))))
 
 (defn msg-handler-fn

--- a/test/kixi/comms/components/kafka_test.clj
+++ b/test/kixi/comms/components/kafka_test.clj
@@ -7,6 +7,7 @@
             [kixi.comms :as comms]
             [kixi.comms.components.kafka :refer :all]
             [kixi.comms.components.test-base :refer :all]
+            [kixi.comms.messages :refer :all]
             [kixi.comms.components.all-component-tests :as all-tests]))
 
 (def zookeeper-ip "127.0.0.1")

--- a/test/kixi/comms/components/kinesis_test.clj
+++ b/test/kixi/comms/components/kinesis_test.clj
@@ -17,7 +17,7 @@
 (def test-dynamodb (env :dynamodb-endpoint "http://localhost:8000"))
 (def test-region "eu-central-1")
 
-(def profile (env :profile "test"))
+(def profile (env :profile "local"))
 (def test-stream-names {:command (str "kixi-comms-test-" profile "-command")
                         :event (str "kixi-comms-test-" profile "-event")})
 (def app-name "kixi-comms")
@@ -82,7 +82,7 @@
 
 (def opts {})
 
-(def long-wait 500)
+(def long-wait 100)
 
 (deftest kinesis-command-roundtrip-test
   (binding [*wait-per-try* long-wait]

--- a/test/kixi/comms/components/kinesis_test.clj
+++ b/test/kixi/comms/components/kinesis_test.clj
@@ -13,13 +13,14 @@
             [amazonica.aws.dynamodbv2 :as ddb]
             [amazonica.aws.kinesis :as kinesis]))
 
-(def test-kinesis (or (env :kinesis-endpoint) "kinesis.eu-central-1.amazonaws.com"))
-(def test-dynamodb (or (env :dynamodb-endpoint) "http://localhost:8000"))
+(def test-kinesis (env :kinesis-endpoint "kinesis.eu-central-1.amazonaws.com"))
+(def test-dynamodb (env :dynamodb-endpoint "http://localhost:8000"))
 (def test-region "eu-central-1")
-(def test-stream-names {:command "kixi-comms-test-command"
-                        :event   "kixi-comms-test-event"})
+
+(def profile (env :profile "test"))
+(def test-stream-names {:command (str "kixi-comms-test-" profile "-command")
+                        :event (str "kixi-comms-test-" profile "-event")})
 (def app-name "kixi-comms")
-(def profile "test")
 
 (def dynamodb-table-names [(event-worker-app-name app-name profile)
                            (command-worker-app-name app-name profile)])

--- a/test/kixi/comms/components/kinesis_test.clj
+++ b/test/kixi/comms/components/kinesis_test.clj
@@ -74,9 +74,7 @@
                              :endpoint test-kinesis
                              :dynamodb-endpoint test-dynamodb
                              :streams test-stream-names
-                             :failover-time-millis 200
-                             :metric-level :NONE
-                             :idle-time-between-reads-in-millis 200}))))))
+                             :metric-level :NONE}))))))
 
 (use-fixtures :once (cycle-system-fixture* kinesis-system system))
 

--- a/test/kixi/comms/components/kinesis_test.clj
+++ b/test/kixi/comms/components/kinesis_test.clj
@@ -82,15 +82,11 @@
 
 (def opts {})
 
-(def long-wait 200)
-
 (deftest kinesis-command-roundtrip-test
-  (binding [*wait-per-try* long-wait]
-    (all-tests/command-roundtrip-test (:kinesis @system) opts)))
+  (all-tests/command-roundtrip-test (:kinesis @system) opts))
 
 (deftest kinesis-event-roundtrip-test
-  (binding [*wait-per-try* long-wait]
-    (all-tests/event-roundtrip-test (:kinesis @system) opts)))
+  (all-tests/event-roundtrip-test (:kinesis @system) opts))
 
 (deftest kinesis-only-correct-handler-gets-message
   (all-tests/only-correct-handler-gets-message (:kinesis @system) opts))

--- a/test/kixi/comms/components/kinesis_test.clj
+++ b/test/kixi/comms/components/kinesis_test.clj
@@ -83,38 +83,40 @@
 
 (def opts {})
 
+(def long-wait 200)
+
 (deftest kinesis-command-roundtrip-test
-  (binding [*wait-per-try* 500]
+  (binding [*wait-per-try* long-wait]
     (all-tests/command-roundtrip-test (:kinesis @system) opts)))
 
 (deftest kinesis-event-roundtrip-test
-  (binding [*wait-per-try* 500]
+  (binding [*wait-per-try* long-wait]
     (all-tests/event-roundtrip-test (:kinesis @system) opts)))
 
 (deftest kinesis-only-correct-handler-gets-message
-  (binding [*wait-per-try* 500]
+  (binding [*wait-per-try* long-wait]
     (all-tests/only-correct-handler-gets-message (:kinesis @system) opts)))
 
 (deftest kinesis-multiple-handlers-get-same-message
-  (binding [*wait-per-try* 500]
+  (binding [*wait-per-try* long-wait]
     (all-tests/multiple-handlers-get-same-message (:kinesis @system) opts)))
 
 (deftest kinesis-roundtrip-command->event
-  (binding [*wait-per-try* 500]
+  (binding [*wait-per-try* long-wait]
     (all-tests/roundtrip-command->event (:kinesis @system) opts)))
 
 (deftest kinesis-roundtrip-command->multi-event
-  (binding [*wait-per-try* 500]
+  (binding [*wait-per-try* long-wait]
     (all-tests/roundtrip-command->multi-event (:kinesis @system) opts)))
 
 (deftest kinesis-roundtrip-command->event-with-key
-  (binding [*wait-per-try* 500]
+  (binding [*wait-per-try* long-wait]
     (all-tests/roundtrip-command->event-with-key (:kinesis @system) opts)))
 
 (deftest kinesis-processing-time-gt-session-timeout
-  (binding [*wait-per-try* 500]
+  (binding [*wait-per-try* long-wait]
     (all-tests/processing-time-gt-session-timeout (:kinesis @system) opts)))
 
 (deftest kinesis-detaching-a-handler
-  (binding [*wait-per-try* 500]
+  (binding [*wait-per-try* long-wait]
     (all-tests/detaching-a-handler (:kinesis @system) opts)))

--- a/test/kixi/comms/components/kinesis_test.clj
+++ b/test/kixi/comms/components/kinesis_test.clj
@@ -77,8 +77,7 @@
                              :streams test-stream-names
                              :failover-time-millis 200
                              :metric-level :NONE
-                             :idle-time-between-reads-in-millis 200
-                             :max-records 1}))))))
+                             :idle-time-between-reads-in-millis 200}))))))
 
 (use-fixtures :once (cycle-system-fixture* kinesis-system system))
 
@@ -93,19 +92,29 @@
     (all-tests/event-roundtrip-test (:kinesis @system) opts)))
 
 (deftest kinesis-only-correct-handler-gets-message
-  (all-tests/only-correct-handler-gets-message (:kinesis @system) opts))
+  (binding [*wait-per-try* 500]
+    (all-tests/only-correct-handler-gets-message (:kinesis @system) opts)))
 
 (deftest kinesis-multiple-handlers-get-same-message
-  (all-tests/multiple-handlers-get-same-message (:kinesis @system) opts))
+  (binding [*wait-per-try* 500]
+    (all-tests/multiple-handlers-get-same-message (:kinesis @system) opts)))
 
 (deftest kinesis-roundtrip-command->event
-  (all-tests/roundtrip-command->event (:kinesis @system) opts))
+  (binding [*wait-per-try* 500]
+    (all-tests/roundtrip-command->event (:kinesis @system) opts)))
+
+(deftest kinesis-roundtrip-command->multi-event
+  (binding [*wait-per-try* 500]
+    (all-tests/roundtrip-command->multi-event (:kinesis @system) opts)))
 
 (deftest kinesis-roundtrip-command->event-with-key
-  (all-tests/roundtrip-command->event-with-key (:kinesis @system) opts))
+  (binding [*wait-per-try* 500]
+    (all-tests/roundtrip-command->event-with-key (:kinesis @system) opts)))
 
 (deftest kinesis-processing-time-gt-session-timeout
-  (all-tests/processing-time-gt-session-timeout (:kinesis @system) opts))
+  (binding [*wait-per-try* 500]
+    (all-tests/processing-time-gt-session-timeout (:kinesis @system) opts)))
 
 (deftest kinesis-detaching-a-handler
-  (all-tests/detaching-a-handler (:kinesis @system) opts))
+  (binding [*wait-per-try* 500]
+    (all-tests/detaching-a-handler (:kinesis @system) opts)))

--- a/test/kixi/comms/components/kinesis_test.clj
+++ b/test/kixi/comms/components/kinesis_test.clj
@@ -93,29 +93,22 @@
     (all-tests/event-roundtrip-test (:kinesis @system) opts)))
 
 (deftest kinesis-only-correct-handler-gets-message
-  (binding [*wait-per-try* long-wait]
-    (all-tests/only-correct-handler-gets-message (:kinesis @system) opts)))
+  (all-tests/only-correct-handler-gets-message (:kinesis @system) opts))
 
 (deftest kinesis-multiple-handlers-get-same-message
-  (binding [*wait-per-try* long-wait]
-    (all-tests/multiple-handlers-get-same-message (:kinesis @system) opts)))
+  (all-tests/multiple-handlers-get-same-message (:kinesis @system) opts))
 
 (deftest kinesis-roundtrip-command->event
-  (binding [*wait-per-try* long-wait]
-    (all-tests/roundtrip-command->event (:kinesis @system) opts)))
+  (all-tests/roundtrip-command->event (:kinesis @system) opts))
 
 (deftest kinesis-roundtrip-command->multi-event
-  (binding [*wait-per-try* long-wait]
-    (all-tests/roundtrip-command->multi-event (:kinesis @system) opts)))
+  (all-tests/roundtrip-command->multi-event (:kinesis @system) opts))
 
 (deftest kinesis-roundtrip-command->event-with-key
-  (binding [*wait-per-try* long-wait]
-    (all-tests/roundtrip-command->event-with-key (:kinesis @system) opts)))
+  (all-tests/roundtrip-command->event-with-key (:kinesis @system) opts))
 
 (deftest kinesis-processing-time-gt-session-timeout
-  (binding [*wait-per-try* long-wait]
-    (all-tests/processing-time-gt-session-timeout (:kinesis @system) opts)))
+  (all-tests/processing-time-gt-session-timeout (:kinesis @system) opts))
 
 (deftest kinesis-detaching-a-handler
-  (binding [*wait-per-try* long-wait]
-    (all-tests/detaching-a-handler (:kinesis @system) opts)))
+  (all-tests/detaching-a-handler (:kinesis @system) opts))

--- a/test/kixi/comms/components/kinesis_test.clj
+++ b/test/kixi/comms/components/kinesis_test.clj
@@ -73,36 +73,48 @@
                              :app app-name
                              :endpoint test-kinesis
                              :dynamodb-endpoint test-dynamodb
-                             :streams test-stream-names
+                             :streams test-stream-names                             
+                             :idle-time-between-reads-in-millis 200
                              :metric-level :NONE}))))))
 
 (use-fixtures :once (cycle-system-fixture* kinesis-system system))
 
 (def opts {})
 
+(def long-wait 500)
+
 (deftest kinesis-command-roundtrip-test
-  (all-tests/command-roundtrip-test (:kinesis @system) opts))
+  (binding [*wait-per-try* long-wait]
+    (all-tests/command-roundtrip-test (:kinesis @system) opts)))
 
 (deftest kinesis-event-roundtrip-test
-  (all-tests/event-roundtrip-test (:kinesis @system) opts))
+  (binding [*wait-per-try* long-wait]
+    (all-tests/event-roundtrip-test (:kinesis @system) opts)))
 
 (deftest kinesis-only-correct-handler-gets-message
-  (all-tests/only-correct-handler-gets-message (:kinesis @system) opts))
+  (binding [*wait-per-try* long-wait]
+    (all-tests/only-correct-handler-gets-message (:kinesis @system) opts)))
 
 (deftest kinesis-multiple-handlers-get-same-message
-  (all-tests/multiple-handlers-get-same-message (:kinesis @system) opts))
+  (binding [*wait-per-try* long-wait]
+    (all-tests/multiple-handlers-get-same-message (:kinesis @system) opts)))
 
 (deftest kinesis-roundtrip-command->event
-  (all-tests/roundtrip-command->event (:kinesis @system) opts))
+  (binding [*wait-per-try* long-wait]
+    (all-tests/roundtrip-command->event (:kinesis @system) opts)))
 
 (deftest kinesis-roundtrip-command->multi-event
-  (all-tests/roundtrip-command->multi-event (:kinesis @system) opts))
+  (binding [*wait-per-try* long-wait]
+    (all-tests/roundtrip-command->multi-event (:kinesis @system) opts)))
 
 (deftest kinesis-roundtrip-command->event-with-key
-  (all-tests/roundtrip-command->event-with-key (:kinesis @system) opts))
+  (binding [*wait-per-try* long-wait]
+    (all-tests/roundtrip-command->event-with-key (:kinesis @system) opts)))
 
 (deftest kinesis-processing-time-gt-session-timeout
-  (all-tests/processing-time-gt-session-timeout (:kinesis @system) opts))
+  (binding [*wait-per-try* long-wait]
+    (all-tests/processing-time-gt-session-timeout (:kinesis @system) opts)))
 
 (deftest kinesis-detaching-a-handler
-  (all-tests/detaching-a-handler (:kinesis @system) opts))
+  (binding [*wait-per-try* long-wait]
+    (all-tests/detaching-a-handler (:kinesis @system) opts)))

--- a/test/kixi/comms/components/test_base.clj
+++ b/test/kixi/comms/components/test_base.clj
@@ -70,3 +70,27 @@
    :kixi.comms.event/version (or (:kixi.comms.command/version cmd)
                                  (:kixi.comms.event/version cmd))
    :kixi.comms.event/payload cmd})
+
+(defn swap-conj-as-multi-events!
+  [a cmd]
+  (swap! a conj cmd)
+  [{:kixi.comms.event/key (-> (or (:kixi.comms.command/key cmd)
+                                  (:kixi.comms.event/key cmd))
+                              (str)
+                              (subs 1)
+                              (str "-event")
+                              (keyword))
+    :kixi.comms.event/version (or (:kixi.comms.command/version cmd)
+                                  (:kixi.comms.event/version cmd))
+    :kixi.comms.event/payload (assoc cmd
+                                     :create-order 1)}
+   {:kixi.comms.event/key (-> (or (:kixi.comms.command/key cmd)
+                                  (:kixi.comms.event/key cmd))
+                              (str)
+                              (subs 1)
+                              (str "-event")
+                              (keyword))
+    :kixi.comms.event/version (or (:kixi.comms.command/version cmd)
+                                  (:kixi.comms.event/version cmd))
+    :kixi.comms.event/payload (assoc cmd
+                                     :create-order 2)}])


### PR DESCRIPTION
When putting messages onto Kinesis streams the command id, if
available, is now used. This ensures that commands and the events they
create will be on the same shard. When a command handler returns multi
events a sequence number is added to ensure that the order is
maintained.

Together these changes should ensure consumers receive events and
commands in the order they are submitting to the streams.

Also, this changes the default number of shards to 3, this will help expose ordering problems.