### PR TITLE
Shard selection key now drawn from command id

### DIFF
--- a/src/kixi/comms/components/kinesis.clj
+++ b/src/kixi/comms/components/kinesis.clj
@@ -128,16 +128,16 @@
         (if msg
           (let [[stream-name-key _ _ _ _ opts] msg
                 stream-name (get stream-names stream-name-key)
-                formatted (apply msg/format-message (conj (vec (butlast msg)) (assoc opts :origin origin)))]
+                formatted (apply msg/format-message (conj (vec (butlast msg)) (assoc opts :origin origin)))
+                seq-num (:seq-num opts)
+                cmd-id (:kixi.comms.command/id opts)]
             (when comms/*verbose-logging*
               (info "Sending msg to Kinesis stream" stream-name ":" formatted))
-            (try
-              (kinesis/put-record {:endpoint endpoint}
-                                  stream-name
-                                  formatted
-                                  (str (java.util.UUID/randomUUID)))
-              (catch Throwable e
-                (error e "Producer threw an exception!")))
+            (kinesis/put-record {:endpoint endpoint}
+                                stream-name
+                                formatted
+                                (or cmd-id (str (java.util.UUID/randomUUID)))
+                                (some-> seq-num str))
             (recur)))))))
 
 (defn attach-generic-processing-switch

--- a/test/kixi/comms/components/kafka_test.clj
+++ b/test/kixi/comms/components/kafka_test.clj
@@ -6,6 +6,7 @@
             [kixi.comms.schema]
             [kixi.comms :as comms]
             [kixi.comms.components.kafka :refer :all]
+            [kixi.comms.messages :refer :all]
             [kixi.comms.components.test-base :refer :all]
             [kixi.comms.components.all-component-tests :as all-tests]))
 

--- a/test/kixi/comms/components/kinesis_test.clj
+++ b/test/kixi/comms/components/kinesis_test.clj
@@ -15,11 +15,13 @@
 
 (def test-kinesis (or (env :kinesis-endpoint) "kinesis.eu-central-1.amazonaws.com"))
 (def test-dynamodb (or (env :dynamodb-endpoint) "http://localhost:8000"))
+
+(def profile (env :profile "local"))
+(def app-name "kixi-comms-test")
+
 (def test-region "eu-central-1")
-(def test-stream-names {:command "kixi-comms-test-command"
-                        :event   "kixi-comms-test-event"})
-(def app-name "kixi-comms")
-(def profile "test")
+(def test-stream-names {:command (str "kixi-comms-test-" profile "-command")
+                        :event   (str "kixi-comms-test-" profile "-event")})
 
 (def dynamodb-table-names [(event-worker-app-name app-name profile)
                            (command-worker-app-name app-name profile)])
@@ -80,28 +82,40 @@
 
 (def opts {})
 
+(def long-wait 500)
+
 (deftest kinesis-command-roundtrip-test
-  (binding [*wait-per-try* 500]
+  (binding [*wait-per-try* long-wait]
     (all-tests/command-roundtrip-test (:kinesis @system) opts)))
 
 (deftest kinesis-event-roundtrip-test
-  (binding [*wait-per-try* 500]
+  (binding [*wait-per-try* long-wait]
     (all-tests/event-roundtrip-test (:kinesis @system) opts)))
 
 (deftest kinesis-only-correct-handler-gets-message
-  (all-tests/only-correct-handler-gets-message (:kinesis @system) opts))
+  (binding [*wait-per-try* long-wait]
+    (all-tests/only-correct-handler-gets-message (:kinesis @system) opts)))
 
 (deftest kinesis-multiple-handlers-get-same-message
-  (all-tests/multiple-handlers-get-same-message (:kinesis @system) opts))
+  (binding [*wait-per-try* long-wait]
+    (all-tests/multiple-handlers-get-same-message (:kinesis @system) opts)))
 
 (deftest kinesis-roundtrip-command->event
-  (all-tests/roundtrip-command->event (:kinesis @system) opts))
+  (binding [*wait-per-try* long-wait]
+    (all-tests/roundtrip-command->event (:kinesis @system) opts)))
 
 (deftest kinesis-roundtrip-command->event-with-key
-  (all-tests/roundtrip-command->event-with-key (:kinesis @system) opts))
+  (binding [*wait-per-try* long-wait]
+    (all-tests/roundtrip-command->event-with-key (:kinesis @system) opts)))
+
+(deftest kinesis-roundtrip-command->multi-event
+  (binding [*wait-per-try* long-wait]
+    (all-tests/roundtrip-command->multi-event (:kinesis @system) opts)))
 
 (deftest kinesis-processing-time-gt-session-timeout
-  (all-tests/processing-time-gt-session-timeout (:kinesis @system) opts))
+  (binding [*wait-per-try* long-wait]
+    (all-tests/processing-time-gt-session-timeout (:kinesis @system) opts)))
 
 (deftest kinesis-detaching-a-handler
-  (all-tests/detaching-a-handler (:kinesis @system) opts))
+  (binding [*wait-per-try* long-wait]
+    (all-tests/detaching-a-handler (:kinesis @system) opts)))

--- a/test/kixi/comms/components/test_base.clj
+++ b/test/kixi/comms/components/test_base.clj
@@ -70,3 +70,19 @@
    :kixi.comms.event/version (or (:kixi.comms.command/version cmd)
                                  (:kixi.comms.event/version cmd))
    :kixi.comms.event/payload cmd})
+
+(defn swap-conj-as-multi-events!
+  [cnt a cmd]
+  (swap! a conj cmd)
+  (do
+    (mapv #(hash-map :kixi.comms.event/key (-> (or (:kixi.comms.command/key cmd)
+                                                   (:kixi.comms.event/key cmd))
+                                               (str)
+                                               (subs 1)
+                                               (str "-event")
+                                               (keyword))
+                     :kixi.comms.event/version (or (:kixi.comms.command/version cmd)
+                                                   (:kixi.comms.event/version cmd))
+                     :kixi.comms.event/payload (assoc cmd
+                                                      :create-order %))
+          (range cnt))))


### PR DESCRIPTION
Shard selection is now enabled by providing the command id as the
shard selection key. This means that events from command will be sent
to same shard as the command. Sequence numbers are also added when
sending multiple events, so they to will be kept in order.