### PR TITLE
Null Reference Exception

### DIFF
--- a/src/kixi/comms/components/kinesis.clj
+++ b/src/kixi/comms/components/kinesis.clj
@@ -115,10 +115,12 @@
 (defn shutdown-workers!
   [workers]
   (doseq [[f ^Worker w id] workers]
-    (info "Shutting down worker" id w)
-    (.shutdown w))
+    (when w
+      (info "Shutting down worker" id w)
+      (.shutdown w)))
   (doseq [[f ^Worker w id] workers]
-    (deref f)))
+    (when f
+      (deref f))))
 
 (defn create-producer
   [endpoint stream-names origin in-chan]

--- a/src/kixi/comms/components/kinesis.clj
+++ b/src/kixi/comms/components/kinesis.clj
@@ -249,7 +249,7 @@
         (create-streams! endpoint (vals streams))
         (create-producer endpoint streams origin producer-chan)
         (merge
-         (assoc component              
+         (assoc component
                 :streams streams
                 :origin origin
                 :producer-in-ch producer-chan)
@@ -262,7 +262,7 @@
                                                (fn [n] (event-worker-app-name n profile))))
                                    id->handle-msg-and-process-msg-atom)})
          (when (:command streams)
-           {:id->command-handle-msg-and-process-msg-atom id->command-handle-msg-and-process-msg-atom            
+           {:id->command-handle-msg-and-process-msg-atom id->command-handle-msg-and-process-msg-atom
             :generic-command-worker (attach-generic-processing-switch
                                      (-> (select-keys component client-config-kws)
                                          (assoc :stream (:command streams))
@@ -276,8 +276,9 @@
         (do
           (info "Stopping Kinesis Producer/Consumer")
           (async/close! producer-in-ch)
-          (shutdown-workers! [(:generic-event-worker component)
-                              (:generic-command-worker component)])
+          (shutdown-workers! (keep identity
+                                   [(:generic-event-worker component)
+                                    (:generic-command-worker component)]))
           (dissoc component
                   :workers
                   :streams

--- a/src/kixi/comms/components/kinesis.clj
+++ b/src/kixi/comms/components/kinesis.clj
@@ -115,12 +115,10 @@
 (defn shutdown-workers!
   [workers]
   (doseq [[f ^Worker w id] workers]
-    (when w
-      (info "Shutting down worker" id w)
-      (.shutdown w)))
+    (info "Shutting down worker" id w)
+    (.shutdown w))
   (doseq [[f ^Worker w id] workers]
-    (when f
-      (deref f))))
+    (deref f)))
 
 (defn create-producer
   [endpoint stream-names origin in-chan]


### PR DESCRIPTION
```
Caused by: java.lang.NullPointerException: null
12:03:03  at kixi.comms.components.kinesis$shutdown_workers_BANG_.invokeStatic (kinesis.clj:119)
12:03:03     kixi.comms.components.kinesis$shutdown_workers_BANG_.invoke (kinesis.clj:115)
12:03:03
kixi.comms.components.kinesis.Kinesis.stop (kinesis.clj:279)
```