### PR TITLE
Msg handler detects and logs infinte loops

### DIFF
--- a/test/kixi/comms/components/all_component_tests.clj
+++ b/test/kixi/comms/components/all_component_tests.clj
@@ -177,3 +177,13 @@
       (is (nil? (wait-for-atom
                  e-result *wait-tries* *wait-per-try*
                  (contains-event-id? id))) (pr-str @e-result)))))
+
+(defn infinite-loop-defended
+  [component opts]
+  (let [result (atom [])
+        id (str (java.util.UUID/randomUUID))]
+    (comms/attach-event-handler! component :component-p :test/foo-c "1.0.0" #(do (swap! result conj %) %))
+    (comms/send-event! component :test/foo-c "1.0.0" {:test "event-infinte-loop-test" :id id})
+    (is (wait-for-atom
+         result *wait-tries* *wait-per-try*
+         (contains-event-id? id)) id)))

--- a/test/kixi/comms/components/kinesis_test.clj
+++ b/test/kixi/comms/components/kinesis_test.clj
@@ -119,3 +119,7 @@
 (deftest kinesis-detaching-a-handler
   (binding [*wait-per-try* long-wait]
     (all-tests/detaching-a-handler (:kinesis @system) opts)))
+
+(deftest kinesis-infinite-loop-defended
+  (binding [*wait-per-try* long-wait]
+    (all-tests/infinite-loop-defended (:kinesis @system) opts)))


### PR DESCRIPTION
If an event handler returns an event with same key and version it is
now just logged as an error, rather than being sent into a infinte
loop of doom.