### PR TITLE
Command and Events can specify partition-key

### DIFF
--- a/test/kixi/comms/components/kafka_test.clj
+++ b/test/kixi/comms/components/kafka_test.clj
@@ -100,3 +100,12 @@
 
 (deftest kafka-detaching-a-handler
   (all-tests/detaching-a-handler (:kafka @system)))
+
+(deftest kafka-events-are-partitioned
+  (all-tests/events-are-partitioned (:kafka @system)))
+
+(deftest kafka-commands-are-partitioned
+  (all-tests/commands-are-partitioned (:kafka @system)))
+
+(deftest kafka-command-produced-events-are-partitioned
+  (all-tests/command-produced-events-are-partitioned(:kafka @system)))

--- a/test/kixi/comms/components/kinesis_test.clj
+++ b/test/kixi/comms/components/kinesis_test.clj
@@ -123,3 +123,15 @@
 (deftest kinesis-infinite-loop-defended
   (binding [*wait-per-try* long-wait]
     (all-tests/infinite-loop-defended (:kinesis @system) opts)))
+
+(deftest kinesis-events-are-partitioned
+  (binding [*wait-per-try* long-wait]
+    (all-tests/events-are-partitioned (:kinesis @system) opts)))
+
+(deftest kinesis-commands-are-partitioned
+  (binding [*wait-per-try* long-wait]
+    (all-tests/commands-are-partitioned (:kinesis @system) opts)))
+
+(deftest kinesis-command-produced-events-are-partitioned
+  (binding [*wait-per-try* long-wait]
+    (all-tests/command-produced-events-are-partitioned (:kinesis @system) opts)))


### PR DESCRIPTION
This should be used for all cmds/events that refer to a single entity,
i.e. metadata id. The partitioning will then ensure that they are
recieved in the order they are sent.