### PR TITLE
Commands and Events can now be validated

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,6 +7,7 @@
   :dependencies [[org.clojure/clojure "1.9.0-alpha14"]
                  [org.clojure/core.async "0.3.443"]
                  [com.cognitect/transit-clj "0.8.290"]
+                 [com.gfredericks/schpec "0.1.1"]
                  [com.taoensso/encore "2.89.0"]
                  [com.stuartsierra/component "0.3.1"]
                  [com.fzakaria/slf4j-timbre "0.3.2"]

--- a/src/kixi/comms.clj
+++ b/src/kixi/comms.clj
@@ -1,4 +1,7 @@
-(ns kixi.comms)
+(ns kixi.comms
+  (:require [clojure.spec :as s]
+            [com.gfredericks.schpec :as sh]
+            [kixi.data-types :as t]))
 
 (def ^:dynamic *verbose-logging* false)
 
@@ -12,14 +15,99 @@
   (send-event!
     [this event version payload]
     [this event version payload opts])
+  (-send-event!
+    [this event opts])
   (send-command!
     [this command version user payload]
     [this command version user payload opts])
+  (-send-command!
+    [this command opts])
   (attach-event-handler!
     [this group-id event version handler])
   (attach-event-with-key-handler!
     [this group-id map-key handler])
+  (attach-validating-event-handler!
+    [this group-id event version handler])
   (attach-command-handler!
+    [this group-id event version handler])
+  (attach-validating-command-handler!
     [this group-id event version handler])
   (detach-handler!
     [this handler]))
+
+
+(s/def ::partition-key string?)
+
+(sh/alias 'command 'kixi.command)
+(sh/alias 'msg 'kixi.message)
+
+(defmulti command-payload (juxt ::command/type
+                                ::command/version))
+
+(s/def ::command/payload
+  (s/multi-spec command-payload
+                (fn [gend-val dispatch-val]
+                  (assoc gend-val
+                         ::command/type (first dispatch-val)
+                         ::command/version (second dispatch-val)))))
+
+(s/def :kixi/command
+  (s/and 
+   (s/merge ::command/payload
+            (s/keys :req [::msg/type
+                          ::command/id
+                          ::command/type
+                          ::command/version
+                          :kixi/user]))
+   #(= :command (::msg/type %))))
+
+(s/def ::command/options
+  (s/keys :req-un [::partition-key]))
+
+(defn send-valid-command!
+  [impl command opts]
+  (let [cmd-with-id (assoc command ::command/id 
+                           (or (::command/id command)
+                               (str (java.util.UUID/randomUUID))))]
+    (when-not (s/valid? :kixi/command cmd-with-id)
+      (throw (ex-info "Invalid command" (s/explain-data :kixi/command cmd-with-id))))
+    (when-not (s/valid? ::command/options opts)
+      (throw (ex-info "Invalid command options" (s/explain-data ::command/options opts))))
+    (-send-command! impl
+                    cmd-with-id
+                    opts)))
+
+(sh/alias 'event 'kixi.event)
+
+(defmulti event-payload (juxt ::event/type
+                              ::event/version))
+
+(s/def ::event/payload
+  (s/multi-spec event-payload
+                (fn [gend-val dispatch-val]
+                  (assoc gend-val
+                         ::event/type (first dispatch-val)
+                         ::event/version (second dispatch-val)))))
+
+(s/def :kixi/event
+  (s/and
+   (s/merge ::event/payload
+            (s/keys :req [::msg/type
+                          ::event/type
+                          ::event/version
+                          ::command/id
+                          :kixi/user]))
+   #(= :event (::msg/type %))))
+
+(s/def ::event/options
+  (s/keys :req-un [::partition-key]))
+
+(defn send-valid-event!
+  [impl event opts]
+  (when-not (s/valid? :kixi/event event)
+    (throw (ex-info "Invalid event" (s/explain-data :kixi/event event))))
+  (when-not (s/valid? ::event/options opts)
+    (throw (ex-info "Invalid event options" (s/explain-data ::event/options opts))))
+  (-send-event! impl
+                event
+                opts))

--- a/src/kixi/comms.clj
+++ b/src/kixi/comms.clj
@@ -43,8 +43,10 @@
 (sh/alias 'event 'kixi.event)
 
 
-(defmulti command-payload (juxt ::command/type
-                                ::command/version))
+(defmulti command-payload 
+  "Implementers must provide a s/keys definition for their command keys"
+  (juxt ::command/type
+        ::command/version))
 
 (s/def ::command/payload
   (s/multi-spec command-payload
@@ -81,8 +83,10 @@
                     cmd-with-id
                     opts)))
 
-(defmulti event-payload (juxt ::event/type
-                              ::event/version))
+(defmulti event-payload
+  "Implementers must provide a s/keys definition for their event keys"
+  (juxt ::event/type
+        ::event/version))
 
 (s/def ::event/payload
   (s/multi-spec event-payload

--- a/src/kixi/data_types.clj
+++ b/src/kixi/data_types.clj
@@ -1,0 +1,22 @@
+(ns kixi.data-types
+  (:require [clojure.spec :as s]
+            [com.gfredericks.schpec :as sh]
+            [kixi.types :as t]))
+
+(sh/alias 'user 'kixi.user)
+
+(s/def ::user/id t/uuid)
+(s/def ::user/groups (s/coll-of t/uuid))
+
+(s/def :kixi/user
+  (s/keys :req [::user/id
+                ::user/groups]))
+
+(sh/alias 'command 'kixi.command)
+
+(s/def ::command/id t/uuid)
+
+(sh/alias 'msg 'kixi.message)
+
+(s/def ::msg/type
+  #{:command :event})

--- a/src/kixi/types.clj
+++ b/src/kixi/types.clj
@@ -4,7 +4,6 @@
             [clojure.spec.gen :as gen]
             [clojure.test.check.generators :as tgen]))
 
-
 (defn -regex?
   [rs]
   (fn [x]

--- a/src/kixi/types.clj
+++ b/src/kixi/types.clj
@@ -1,0 +1,21 @@
+(ns kixi.types
+  (:require [clojure.spec :as s]
+            [com.gfredericks.schpec :as sh]
+            [clojure.spec.gen :as gen]
+            [clojure.test.check.generators :as tgen]))
+
+
+(defn -regex?
+  [rs]
+  (fn [x]
+    (if (and (string? x) (re-find rs x)) 
+      x 
+      :clojure.spec/invalid)))
+
+(def uuid?
+  (-regex? #"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"))
+
+(def uuid 
+  (s/with-gen 
+    (s/conformer uuid?)
+    #(tgen/no-shrink (gen/fmap str (gen/uuid)))))

--- a/test/kixi/comms/components/all_component_tests.clj
+++ b/test/kixi/comms/components/all_component_tests.clj
@@ -104,7 +104,7 @@
                                   :kixi/user user 
                                   :test "validated-command-roundtrip-test" 
                                   :id id}
-                                 {:partition-key ""})
+                                 {:partition-key id})
       (is (wait-for-atom
            result *wait-tries* *wait-per-try*
            (contains-command-id? id)) id)))
@@ -120,7 +120,7 @@
                                                           :kixi.user/id)
                                        :test "command-invalid-test" 
                                        :id id}
-                                      {:partition-key ""})))))
+                                      {:partition-key id})))))
   (testing "Validated command type to event type conditions are applied"
     (let [result (atom [])
           id (str (java.util.UUID/randomUUID))]
@@ -135,7 +135,7 @@
                                   :kixi/user user 
                                   :test "validated-command-type-condition-applied" 
                                   :id id}
-                                 {:partition-key ""})
+                                 {:partition-key id})
       (is (wait-for-atom
            result *wait-tries* *wait-per-try*
            (contains-command-id? id)) id))))
@@ -153,7 +153,7 @@
   (testing "Validated event send"
     (let [result (atom [])
           id (str (java.util.UUID/randomUUID))]
-      (comms/attach-validating-event-handler! component :component-b :test/vfoo-b "1.0.0" (partial swap-conj-as-cmd! result))
+      (comms/attach-validating-event-handler! component :component-b :test/vfoo-b "1.0.0" (partial swap-conj! result))
       (comms/send-valid-event! component 
                                {:kixi.message/type :event
                                 ::event/type :test/vfoo-b
@@ -162,7 +162,7 @@
                                 :kixi/user user
                                 :test "event-validating-roundtrip-test"
                                 :id id}
-                               {:partition-key ""})
+                               {:partition-key id})
       (is (wait-for-atom
            result *wait-tries* *wait-per-try*
            (contains-event-id? id)) id)))
@@ -178,7 +178,7 @@
                                      :kixi/user user
                                      :test "event-invalid-roundtrip-test"
                                      :id id}
-                                    {:partition-key ""}))))))
+                                    {:partition-key id}))))))
 
 (defn only-correct-handler-gets-message
   [component opts]

--- a/test/kixi/comms/components/all_component_tests.clj
+++ b/test/kixi/comms/components/all_component_tests.clj
@@ -1,7 +1,11 @@
 (ns kixi.comms.components.all-component-tests
   (:require  [clojure.test :refer :all]
+             [clojure.spec :as s]
+             [clojure.spec.test :as st]
+             [com.gfredericks.schpec :as sh]
              [kixi.comms :as comms]
-             [kixi.comms.components.test-base :refer :all]))
+             [kixi.comms.components.test-base :refer :all]
+             [clojure.spec :as s]))
 
 (def long-session-timeout 10000)
 
@@ -10,33 +14,131 @@
 (defn contains-event-id?
   [id]
   (fn [events]
-    (some (fn [c] (when (= id (get-in c [:kixi.comms.event/payload :id])) c)) events)))
+    (some (fn [c] (when (= id (or (get-in c [:kixi.comms.event/payload :id])
+                                  (:id c)))
+                    c)) 
+          events)))
 
 (defn contains-command-id?
   [id]
   (fn [commands]
-    (some (fn [c] (when (= id (get-in c [:kixi.comms.command/payload :id])) c)) commands)))
+    (some (fn [c] (when (= id (or (get-in c [:kixi.comms.command/payload :id])
+                                  (:id c))) c)) 
+          commands)))
+
+(sh/alias 'command 'kixi.command)
+(sh/alias 'event 'kixi.event)
+
+(st/instrument ['kixi.comms/send-valid-command!
+                'kixi.comms/send-valid-event!])
+
+(s/def ::test string?)
+(s/def ::id string?)
+
+(defmethod kixi.comms/command-payload
+  [:test/vfoo "1.0.0"]
+  [_]
+  (s/keys :req-un [::test
+                   ::id]))
+
+(defmethod kixi.comms/event-payload
+  [:test/vfoo-event "1.0.0"]
+  [_]
+  (s/keys :req-un [::test
+                   ::id]))
+
+(defmethod kixi.comms/event-payload
+  [:test/vfoo-b "1.0.0"]
+  [_]
+  (s/keys :req-un [::test
+                   ::id]))
+
+(defmethod kixi.comms/command-payload
+  [:test/vfoo-b-cmd "1.0.0"]
+  [_]
+  (s/keys :req-un [::test
+                   ::id]))
 
 (defn command-roundtrip-test
-  [component opts]
-  (let [result (atom [])
-        id (str (java.util.UUID/randomUUID))]
-    (comms/attach-command-handler! component :component-a :test/foo "1.0.0"
-                                   (partial swap-conj-as-event! result))
-    (comms/send-command! component :test/foo "1.0.0" user {:test "command-roundtrip-test" :id id})
-    (is (wait-for-atom
-         result *wait-tries* *wait-per-try*
-         (contains-command-id? id)) id)))
+  [component opts]  
+  (testing "Unvalidated command send"
+    (let [result (atom [])
+          id (str (java.util.UUID/randomUUID))]
+      (comms/attach-command-handler! component :component-a :test/foo "1.0.0"
+                                     (partial swap-conj-as-event! result))
+      (comms/send-command! component :test/foo "1.0.0" user {:test "command-roundtrip-test" :id id})
+      (is (wait-for-atom
+           result *wait-tries* *wait-per-try*
+           (contains-command-id? id)) id)))
+  (testing "Validated command send"
+    (let [result (atom [])
+          id (str (java.util.UUID/randomUUID))]
+      (comms/attach-validating-command-handler! component :component-a :test/vfoo "1.0.0"
+                                                (partial swap-conj-as-event! result))
+      (comms/send-valid-command! component 
+                                 {:kixi.message/type :command
+                                  ::command/type :test/vfoo
+                                  ::command/version "1.0.0"
+                                  :kixi/user user 
+                                  :test "validated-command-roundtrip-test" 
+                                  :id id}
+                                 {:partition-key ""})
+      (is (wait-for-atom
+           result *wait-tries* *wait-per-try*
+           (contains-command-id? id)) id)))
+  (testing "Validated command send - invalid command"
+    (let [id (str (java.util.UUID/randomUUID))]
+      (is (thrown-with-msg?
+           Exception
+           #"Invalid command"
+           (comms/send-valid-command! component 
+                                      {::command/type :test/vfoo
+                                       ::command/version "1.0.0" 
+                                       :kixi/user (dissoc user
+                                                          :kixi.user/id)
+                                       :test "command-invalid-test" 
+                                       :id id}
+                                      {:partition-key ""}))))))
 
 (defn event-roundtrip-test
   [component opts]
-  (let [result (atom [])
-        id (str (java.util.UUID/randomUUID))]
-    (comms/attach-event-handler! component :component-b :test/foo-b "1.0.0" (partial swap-conj-as-event! result))
-    (comms/send-event! component :test/foo-b "1.0.0" {:test "event-roundtrip-tes" :id id})
-    (is (wait-for-atom
-         result *wait-tries* *wait-per-try*
-         (contains-event-id? id)) id)))
+  (testing "Unvalidated event send"
+    (let [result (atom [])
+          id (str (java.util.UUID/randomUUID))]
+      (comms/attach-event-handler! component :component-b :test/foo-b "1.0.0" (partial swap-conj-as-event! result))
+      (comms/send-event! component :test/foo-b "1.0.0" {:test "event-roundtrip-test" :id id})
+      (is (wait-for-atom
+           result *wait-tries* *wait-per-try*
+           (contains-event-id? id)) id)))
+  (testing "Validated event send"
+    (let [result (atom [])
+          id (str (java.util.UUID/randomUUID))]
+      (comms/attach-validating-event-handler! component :component-b :test/vfoo-b "1.0.0" (partial swap-conj-as-cmd! result))
+      (comms/send-valid-event! component 
+                               {:kixi.message/type :event
+                                ::event/type :test/vfoo-b
+                                ::event/version "1.0.0"
+                                ::command/id id
+                                :kixi/user user
+                                :test "event-validating-roundtrip-test"
+                                :id id}
+                               {:partition-key ""})
+      (is (wait-for-atom
+           result *wait-tries* *wait-per-try*
+           (contains-event-id? id)) id)))
+  (testing "Validated event send - invalid event"
+    (let [id (str (java.util.UUID/randomUUID))]
+      (is (thrown-with-msg?
+           Exception
+           #"Invalid event"
+           (comms/send-valid-event! component 
+                                    {::event/type :test/vfoo-b
+                                     ::event/version "1.0.0"
+                                     ::command/id "not-valid-cmd-id"
+                                     :kixi/user user
+                                     :test "event-invalid-roundtrip-test"
+                                     :id id}
+                                    {:partition-key ""}))))))
 
 (defn only-correct-handler-gets-message
   [component opts]

--- a/test/kixi/comms/components/coreasync_test.clj
+++ b/test/kixi/comms/components/coreasync_test.clj
@@ -52,44 +52,44 @@
 
 (def long-wait 50)
 
-(deftest kinesis-command-roundtrip-test
+(deftest coreasync-command-roundtrip-test
   (binding [*wait-per-try* long-wait]
     (all-tests/command-roundtrip-test (:coreasync @system) opts)))
 
-(deftest kinesis-event-roundtrip-test
+(deftest coreasync-event-roundtrip-test
   (binding [*wait-per-try* long-wait]
     (all-tests/event-roundtrip-test (:coreasync @system) opts)))
 
-(deftest kinesis-only-correct-handler-gets-message
+(deftest coreasync-only-correct-handler-gets-message
   (binding [*wait-per-try* long-wait]
     (all-tests/only-correct-handler-gets-message (:coreasync @system) opts)))
 
-(deftest kinesis-multiple-handlers-get-same-message
+(deftest coreasync-multiple-handlers-get-same-message
   (binding [*wait-per-try* long-wait]
     (all-tests/multiple-handlers-get-same-message (:coreasync @system) opts)))
 
-(deftest kinesis-roundtrip-command->event
+(deftest coreasync-roundtrip-command->event
   (binding [*wait-per-try* long-wait]
     (all-tests/roundtrip-command->event (:coreasync @system) opts)))
 
-(deftest kinesis-roundtrip-command->event-with-key
+(deftest coreasync-roundtrip-command->event-with-key
   (binding [*wait-per-try* long-wait]
     (all-tests/roundtrip-command->event-with-key (:coreasync @system) opts)))
 
-(deftest kinesis-roundtrip-command->multi-event
+(deftest coreasync-roundtrip-command->multi-event
   (binding [*wait-per-try* long-wait]
     (all-tests/roundtrip-command->multi-event (:coreasync @system) opts)))
 
 (comment "Test not applicable as core async has no session"
-         (deftest kinesis-processing-time-gt-session-timeout
+         (deftest coreasync-processing-time-gt-session-timeout
            (binding [*wait-per-try* long-wait]
              (all-tests/processing-time-gt-session-timeout (:coreasync @system) opts))))
 
-(deftest kinesis-detaching-a-handler
+(deftest coreasync-detaching-a-handler
   (binding [*wait-per-try* long-wait]
     (all-tests/detaching-a-handler (:coreasync @system) opts)))
 
-(deftest kinesis-infinite-loop-defended
+(deftest coreasync-infinite-loop-defended
   (binding [*wait-per-try* long-wait]
     (all-tests/infinite-loop-defended (:coreasync @system) opts)))
 

--- a/test/kixi/comms/components/test_base.clj
+++ b/test/kixi/comms/components/test_base.clj
@@ -113,6 +113,10 @@
   (swap! a conj event)
   (event->cmd event))
 
+(defn swap-conj!
+  [a event]
+  (swap! a conj event))
+
 (defn swap-conj-as-multi-events!
   [cnt a cmd]
   (swap! a conj cmd)

--- a/test/kixi/comms/components/test_base.clj
+++ b/test/kixi/comms/components/test_base.clj
@@ -1,10 +1,19 @@
 (ns kixi.comms.components.test-base
   (:require [com.stuartsierra.component :as component]
+            [com.gfredericks.schpec :as sh]
             [taoensso.timbre :as timbre :refer [error info]]
             [environ.core :refer [env]]))
 
 (def ^:dynamic *wait-tries* (Integer/parseInt (env :wait-tries "160")))
 (def ^:dynamic *wait-per-try* (Integer/parseInt (env :wait-per-try "100")))
+
+(sh/alias 'msg 'kixi.message)
+(sh/alias 'command 'kixi.command)
+(sh/alias 'event 'kixi.event)
+
+(defn old-format?
+  [msg]
+  (not (::msg/type msg)))
 
 (defn wait
   [ms]
@@ -60,20 +69,55 @@
 
 (defn cmd->event
   [cmd]
-  {:kixi.comms.event/key (-> (or (:kixi.comms.command/key cmd)
-                                 (:kixi.comms.event/key cmd))
-                             (str)
-                             (subs 1)
-                             (str "-event")
-                             (keyword))
-   :kixi.comms.event/version (or (:kixi.comms.command/version cmd)
-                                 (:kixi.comms.event/version cmd))
-   :kixi.comms.event/payload cmd})
+  (if (old-format? cmd)
+    {:kixi.comms.event/key (-> (or (:kixi.comms.command/key cmd)
+                                   (:kixi.comms.event/key cmd))
+                               (str)
+                               (subs 1)
+                               (str "-event")
+                               (keyword))
+     :kixi.comms.event/version (or (:kixi.comms.command/version cmd)
+                                   (:kixi.comms.event/version cmd))
+     :kixi.comms.event/payload cmd}
+    [(merge {::event/type (-> cmd
+                              ::command/type
+                              (str)
+                              (subs 1)
+                              (str "-event")
+                              (keyword))
+             ::event/version (::command/version cmd)
+             ::msg/type :event}
+            (dissoc cmd
+                    ::command/type
+                    ::command/version
+                    ::msg/type))
+     {:partition-key "1"}]))
+
+(defn event->cmd
+  [event]
+  [(merge {::command/type (-> event
+                              ::event/type
+                              (str)
+                              (subs 1)
+                              (str "-cmd")
+                              (keyword))
+           ::command/version (::event/version event)
+           ::msg/type :command}
+          (dissoc event
+                  ::event/type
+                  ::event/version
+                  ::msg/type))
+   {:partition-key "1"}])
 
 (defn swap-conj-as-event!
   [a cmd]
   (swap! a conj cmd)
   (cmd->event cmd))
+
+(defn swap-conj-as-cmd!
+  [a event]
+  (swap! a conj event)
+  (event->cmd event))
 
 (defn swap-conj-as-multi-events!
   [cnt a cmd]

--- a/test/kixi/comms/components/test_base.clj
+++ b/test/kixi/comms/components/test_base.clj
@@ -85,12 +85,9 @@
                               (subs 1)
                               (str "-event")
                               (keyword))
-             ::event/version (::command/version cmd)
-             ::msg/type :event}
-            (dissoc cmd
-                    ::command/type
-                    ::command/version
-                    ::msg/type))
+             ::event/version (::command/version cmd)}
+            (select-keys cmd
+                         [:id :test]))
      {:partition-key "1"}]))
 
 (defn event->cmd
@@ -101,12 +98,9 @@
                               (subs 1)
                               (str "-cmd")
                               (keyword))
-           ::command/version (::event/version event)
-           ::msg/type :command}
-          (dissoc event
-                  ::event/type
-                  ::event/version
-                  ::msg/type))
+           ::command/version (::event/version event)}
+          (select-keys event
+                       [:id :test]))
    {:partition-key "1"}])
 
 (defn swap-conj-as-event!

--- a/test/kixi/comms/messages_test.clj
+++ b/test/kixi/comms/messages_test.clj
@@ -1,9 +1,11 @@
 (ns kixi.comms.messages-test
   (:require [kixi.comms.messages :refer :all]
+            [kixi.comms :as comms]
             [kixi.comms.components.test-base :refer :all]
             [clojure
              [spec :as s]
-             [test :refer :all]]))
+             [test :refer :all]]
+            [com.gfredericks.schpec :as sh]))
 
 (deftest formatting-tests
   (is (not
@@ -12,3 +14,36 @@
   (is (not
        (s/explain-data :kixi.comms.message/event
                        (format-message :event :test/foo "1.0.0" user {:foo :bar} {:origin "local"})))))
+
+
+(sh/alias 'event 'kixi.event)
+(sh/alias 'cmd 'kixi.command)
+
+(deftest validate-cmd-type->event-types-test
+  (defmethod comms/command-type->event-types
+    [:cmd-test "1.0.0"]
+    [_]
+    #{[:event-test "1.0.0"] [:event-test2 "1.0.0"]})
+  (testing "Finds match"
+    (is (nil? (validate-cmd-type->event-types {::cmd/type :cmd-test ::cmd/version "1.0.0"} [{:event {::event/type :event-test ::event/version "1.0.0"}}])))
+    (is (nil? (validate-cmd-type->event-types {::cmd/type :cmd-test ::cmd/version "1.0.0"} [{:event {::event/type :event-test2 ::event/version "1.0.0"}}]))))
+  (testing "Exception on non match"
+    (is (thrown?
+         Exception
+         (validate-cmd-type->event-types {::cmd/type :cmd-test ::cmd/version "1.0.0"} [{:event {::event/type :un-regd ::event/version "1.0.0"}}]))))
+  (remove-method comms/command-type->event-types [:cmd-test "1.0.0"]))
+
+
+(deftest validate-event-type->command-types-test
+  (defmethod comms/event-type->command-types
+    [:event-test "1.0.0"]
+    [_]
+    #{[:cmd-test "1.0.0"] [:cmd-test2 "1.0.0"]})
+  (testing "Finds match"
+    (is (nil? (validate-event-type->command-types {::event/type :event-test ::event/version "1.0.0"} [{:cmd {::cmd/type :cmd-test ::cmd/version "1.0.0"}}])))
+    (is (nil? (validate-event-type->command-types {::event/type :event-test ::event/version "1.0.0"} [{:cmd {::cmd/type :cmd-test2 ::cmd/version "1.0.0"}}]))))
+  (testing "Exception on non match"
+    (is (thrown?
+         Exception
+         (validate-cmd-type->event-types {::event/type :cmd-test ::event/version "1.0.0"} [{:cmd {::cmd/type :un-regd ::cmd/version "1.0.0"}}]))))
+  (remove-method  comms/event-type->command-types [:event-test "1.0.0"]))


### PR DESCRIPTION
New send fn's have been added to the comms protocol namespace. These
have fdef's that can be intrumented at runtime to validate sent commands
and events.

Command and event specs are defined via a multi-spec for per service
extention.

Introduced kixi.types namespace for comman types. We should make this
namespace common accross all services, eventually pulling into a lib
if/when we see fit.

Introduced kixi.data-types for common data types, like user. Again we
should push this pattern out into the services, lib'ing as we see fit.