### PR TITLE
Remove code where invalid commands (spec/valid?) cause an exception

### DIFF
--- a/src/kixi/comms/messages.clj
+++ b/src/kixi/comms/messages.clj
@@ -139,8 +139,6 @@
 (defn command-handler
   [comms-component service-cmd-handler]
   (fn [command]
-    (when-not (s/valid? :kixi/command command)
-      (throw (ex-info "Invalid command" (s/explain-data :kixi/command command))))
     (let [result (service-cmd-handler command)]
       (when-not (s/valid? ::command-result result)
         (throw (ex-info "Invalid command result" (s/explain-data ::command-result result))))


### PR DESCRIPTION
We would like command handlers to generate more context aware
rejection/invalid events when something in the command is
wrong. Commands must have achieved a basic level of validation by this
point to have even been matched with a command handler. Command
handlers should therefore attempt to diagnose what is invalid about a
command and respond with an appropriate event, such as a rejection
event, with better information for the user about why the rejection occurred.