### PR TITLE
Forcing explicit partition key in old formats

### DIFF
--- a/test/kixi/comms/components/all_component_tests.clj
+++ b/test/kixi/comms/components/all_component_tests.clj
@@ -87,7 +87,9 @@
           id (new-uuid)]
       (comms/attach-command-handler! component :component-a :test/foo "1.0.0"
                                      (partial swap-conj-as-event! result))
-      (comms/send-command! component :test/foo "1.0.0" user {:test "command-roundtrip-test" :id id})
+      (comms/send-command! component :test/foo "1.0.0" user
+                           {:test "command-roundtrip-test" :id id}
+                           {:kixi.comms.command/partition-key id})
       (is (wait-for-atom
            result *wait-tries* *wait-per-try*
            (contains-command-id? id)) id)))
@@ -145,7 +147,9 @@
     (let [result (atom [])
           id (new-uuid)]
       (comms/attach-event-handler! component :component-b :test/foo-b "1.0.0" (partial swap-conj-as-event! result))
-      (comms/send-event! component :test/foo-b "1.0.0" {:test "event-roundtrip-test" :id id})
+      (comms/send-event! component :test/foo-b "1.0.0"
+                         {:test "event-roundtrip-test" :id id}
+                         {:kixi.comms.event/partition-key id})
       (is (wait-for-atom
            result *wait-tries* *wait-per-try*
            (contains-event-id? id)) id)))
@@ -186,7 +190,9 @@
         id (new-uuid)]
     (comms/attach-event-handler! component :component-c :test/foo-c "1.0.0" (partial swap-conj-as-event! result))
     (comms/attach-event-handler! component :component-d :test/foo-c "1.0.1" (partial reset-as-event! fail))
-    (comms/send-event! component :test/foo-c "1.0.0" {:test "only-correct-handler-gets-message" :id id})
+    (comms/send-event! component :test/foo-c "1.0.0"
+                       {:test "only-correct-handler-gets-message" :id id}
+                       {:kixi.comms.event/partition-key id})
     (is (wait-for-atom
          result *wait-tries* *wait-per-try*
          (contains-event-id? id)) id)
@@ -199,7 +205,9 @@
         id (new-uuid)]
     (comms/attach-event-handler! component :component-e :test/foo-e "1.0.0" (partial swap-conj-as-event! result1))
     (comms/attach-event-handler! component :component-f :test/foo-e "1.0.0" (partial swap-conj-as-event! result2))
-    (comms/send-event! component :test/foo-e "1.0.0" {:test "multiple-handlers-get-same-message" :id id})
+    (comms/send-event! component :test/foo-e "1.0.0"
+                       {:test "multiple-handlers-get-same-message" :id id}
+                       {:kixi.comms.event/partition-key id})
     (is (wait-for-atom
          result1 *wait-tries* *wait-per-try*
          (contains-event-id? id)) id)
@@ -216,7 +224,9 @@
                           (some (fn [e] (when (= id (get-in e [:kixi.comms.event/payload :kixi.comms.command/payload :id])) e)) events))]
     (comms/attach-command-handler! component :component-g :test/test-a "1.0.0" (partial swap-conj-as-event! c-result))
     (comms/attach-event-handler! component :component-h :test/test-a-event "1.0.0" (fn [x] (swap! e-result conj x) nil))
-    (comms/send-command! component :test/test-a "1.0.0" user {:test "roundtrip-command->event" :id id})
+    (comms/send-command! component :test/test-a "1.0.0" user
+                         {:test "roundtrip-command->event" :id id :partition-key id}
+                         {:kixi.comms.command/partition-key id})
     (is (wait-for-atom
          c-result *wait-tries* *wait-per-try*
          (contains-command-id? id)) id)
@@ -238,7 +248,9 @@
                            (filter (fn [e] (= id (get-in e [:kixi.comms.event/payload :kixi.comms.command/payload :id]))) events))]
     (comms/attach-command-handler! component :component-n :test/test-b "1.0.0" (partial swap-conj-as-multi-events! event-count c-result))
     (comms/attach-event-handler! component :component-o :test/test-b-event "1.0.0" (fn [x] (swap! e-result conj x) nil))
-    (comms/send-command! component :test/test-b "1.0.0" user {:test "roundtrip-command->multi-events" :id id})
+    (comms/send-command! component :test/test-b "1.0.0" user
+                         {:test "roundtrip-command->multi-events" :id id :partition-key id}
+                         {:kixi.comms.command/partition-key id})
     (is (wait-for-atom
          c-result *wait-tries* *wait-per-try*
          (contains-command-id? id)))
@@ -266,7 +278,9 @@
                                           :component-k
                                           :kixi.comms.command/id
                                           (fn [x] (swap! e-result conj x) nil))
-    (comms/send-command! component :test/test-xyz "1.0.0" user {:test "roundtrip-command->event-with-key" :id id})
+    (comms/send-command! component :test/test-xyz "1.0.0" user
+                         {:test "roundtrip-command->event-with-key" :id id}
+                         {:kixi.comms.command/partition-key id})
     (is (wait-for-atom
          c-result *wait-tries* *wait-per-try*
          (contains-command-id? id)) id)
@@ -286,11 +300,14 @@
         id2 (new-uuid)]
     (comms/attach-event-handler! component :component-i :test/foo-f "1.0.0" #(do (wait long-session-timeout)
                                                                                  (swap-conj-as-event! result %)))
-    (comms/send-event! component :test/foo-f "1.0.0" {:test "processing-time-gt-session-timeout" :id id})
+    (comms/send-event! component :test/foo-f "1.0.0"
+                       {:test "processing-time-gt-session-timeout" :id id}
+                       {:kixi.comms.event/partition-key id})
     (is (wait-for-atom
          result *wait-tries* *wait-per-try*
          (contains-event-id? id)))
-    (comms/send-event! component :test/foo-f "1.0.0" {:test "processing-time-gt-session-timeout-2" :id id2})
+    (comms/send-event! component :test/foo-f "1.0.0" {:test "processing-time-gt-session-timeout-2" :id id2}
+                       {:kixi.comms.event/partition-key id2})
     (is (wait-for-atom
          result *wait-tries* *wait-per-try*
          (contains-event-id? id2)))))
@@ -305,7 +322,9 @@
     (comms/attach-command-handler! component :component-l :test/test-a "1.0.0"
                                    (partial swap-conj-as-event! c-result))
     (let [eh (comms/attach-event-handler! component :component-m :test/test-a-event "1.0.0" (fn [x] (swap! e-result conj x) nil))]
-      (comms/send-command! component :test/test-a "1.0.0" user {:test "detaching-a-handler" :id id})
+      (comms/send-command! component :test/test-a "1.0.0" user
+                           {:test "detaching-a-handler" :id id}
+                           {:kixi.comms.command/partition-key id})
       (is (wait-for-atom
            c-result *wait-tries* *wait-per-try*
            (contains-command-id? id)) id)
@@ -314,7 +333,9 @@
            (partial event-finder-fn id)) id)
       (reset! e-result [])
       (comms/detach-handler! component eh)
-      (comms/send-command! component :test/test-a "1.0.0" user {:test "detaching-a-handler-2" :id id})
+      (comms/send-command! component :test/test-a "1.0.0" user
+                           {:test "detaching-a-handler-2" :id id :partition-key id}
+                           {:kixi.comms.command/partition-key id})
       (is (nil? (wait-for-atom
                  e-result *wait-tries* *wait-per-try*
                  (contains-event-id? id))) (pr-str @e-result)))))
@@ -324,7 +345,9 @@
   (let [result (atom [])
         id (new-uuid)]
     (comms/attach-event-handler! component :component-p :test/foo-c "1.0.0" #(do (swap! result conj %) %))
-    (comms/send-event! component :test/foo-c "1.0.0" {:test "event-infinte-loop-test" :id id})
+    (comms/send-event! component :test/foo-c "1.0.0"
+                       {:test "event-infinte-loop-test" :id id}
+                       {:kixi.comms.event/partition-key id})
     (is (wait-for-atom
          result *wait-tries* *wait-per-try*
          (contains-event-id? id)) id)))

--- a/test/kixi/comms/components/test_base.clj
+++ b/test/kixi/comms/components/test_base.clj
@@ -65,7 +65,8 @@
                              (keyword))
    :kixi.comms.event/version (or (:kixi.comms.command/version cmd)
                                  (:kixi.comms.event/version cmd))
-   :kixi.comms.event/payload cmd})
+   :kixi.comms.event/payload cmd
+   :kixi.comms.event/partition-key "0"})
 
 (defn cmd->event
   [cmd]
@@ -78,7 +79,8 @@
                                (keyword))
      :kixi.comms.event/version (or (:kixi.comms.command/version cmd)
                                    (:kixi.comms.event/version cmd))
-     :kixi.comms.event/payload cmd}
+     :kixi.comms.event/payload cmd
+     :kixi.comms.event/partition-key "0"}
     [(merge {::event/type (-> cmd
                               ::command/type
                               (str)


### PR DESCRIPTION
This is enforced in the newer format, at the time it was thought we
would migrate quickly, we havn't.

This change adds this crucial concept to the older format.