### PR TITLE
Removing the send msg versions that don't require opts

### DIFF
--- a/src/kixi/comms.clj
+++ b/src/kixi/comms.clj
@@ -16,12 +16,10 @@
   "send-event opts: command-id
    send-command opts: origin, id"
   (send-event!
-    [this event version payload]
     [this event version payload opts])
   (-send-event!
     [this event opts])
   (send-command!
-    [this command version user payload]
     [this command version user payload opts])
   (-send-command!
     [this command opts])

--- a/src/kixi/comms/components/coreasync.clj
+++ b/src/kixi/comms/components/coreasync.clj
@@ -38,34 +38,28 @@
                       id->command-handle-msg-and-process-msg-atom]
   comms/Communications
 
-  (send-event! [comms event version payload]
-    (comms/send-event! comms event version payload {}))
-
   (send-event! [{:keys [event-chan]} event version payload opts]
     (when event-chan
       (debug "# Putting event: " event version)
-      (async/put! event-chan 
+      (async/put! event-chan
                   (msg/format-message :event event version nil payload opts))))
 
-  (-send-event! [{:keys [event-chan]} event opts]    
+  (-send-event! [{:keys [event-chan]} event opts]
     (when event-chan
       (debug "# Putting event: " event)
       (async/put! event-chan event)))
 
-  (send-command! [comms command version user payload]
-    (comms/send-command! comms command version user payload {}))
-
   (send-command! [{:keys [cmd-chan]} command version user payload opts]
     (when cmd-chan
       (debug "# Putting command: " command version)
-      (async/put! cmd-chan 
+      (async/put! cmd-chan
                   (msg/format-message :command command version user payload opts))))
 
   (-send-command! [{:keys [cmd-chan]} command opts]
     (when cmd-chan
       (debug "# Putting command: " command)
       (async/put! cmd-chan command)))
-  
+
   (attach-event-with-key-handler!
     [{:keys [stream-names workers] :as this}
      group-id map-key handler]
@@ -116,7 +110,7 @@
                  :handle-msg  (msg/msg-handler-fn handler
                                                   (partial msg/handle-result this :command))})
       id))
-  
+
   (attach-validating-command-handler!
     [{:keys [stream-names workers] :as this}
      group-id command version handler]
@@ -168,4 +162,3 @@
                   :origin
                   :producer-in-ch))
         component))))
-

--- a/src/kixi/comms/components/kafka.clj
+++ b/src/kixi/comms/components/kafka.clj
@@ -176,9 +176,6 @@
     (when producer-in-ch
       (async/put! producer-in-ch [:event event version nil payload opts])))
 
-  (send-command! [comms command version user payload]
-    (comms/send-command! comms command version user payload {}))
-
   (send-command! [{:keys [producer-in-ch]} command version user payload opts]
     (when producer-in-ch
       (async/put! producer-in-ch [:command command version user payload opts])))

--- a/src/kixi/comms/components/kinesis.clj
+++ b/src/kixi/comms/components/kinesis.clj
@@ -194,8 +194,6 @@
                     producer-in-chan id->handle-msg-and-process-msg-atom
                     id->command-handle-msg-and-process-msg-atom]
   comms/Communications
-  (send-event! [comms event version payload]
-    (comms/send-event! comms event version payload {}))
 
   (send-event! [{:keys [producer-in-ch]} event version payload opts]
     (when producer-in-ch
@@ -205,9 +203,6 @@
     (when producer-in-ch
       (debug "# Putting event: " event)
       (async/put! producer-in-ch [:event event opts])))
-
-  (send-command! [comms command version user payload]
-    (comms/send-command! comms command version user payload {}))
 
   (send-command! [{:keys [producer-in-ch]} command version user payload opts]
     (when producer-in-ch

--- a/test/kixi/comms/messages_test.clj
+++ b/test/kixi/comms/messages_test.clj
@@ -23,13 +23,9 @@
   [cmd events]
   ((command-handler (reify comms/Communications
                       (send-event!
-                          [this event version payload])
-                      (send-event!
                           [this event version payload opts])
                       (-send-event!
                           [this event opts])
-                      (send-command!
-                          [this command version user payload])
                       (send-command!
                           [this command version user payload opts])
                       (-send-command!
@@ -58,13 +54,9 @@
   [event cmds]
   ((event-handler (reify comms/Communications
                       (send-event!
-                          [this event version payload])
-                      (send-event!
                           [this event version payload opts])
                       (-send-event!
                           [this event opts])
-                      (send-command!
-                          [this command version user payload])
                       (send-command!
                           [this command version user payload opts])
                       (-send-command!


### PR DESCRIPTION
We now require opts, as that is where the partition key is provided,
this should stop anyone compiling stuff that doesn't work.