### PR TITLE
Unhandled exceptions now cause the kinesis consumer to be shutdown

### DIFF
--- a/src/kixi/comms/messages.clj
+++ b/src/kixi/comms/messages.clj
@@ -94,10 +94,7 @@
 (defn msg-handler-fn
   [component-handler result-handler]
   (fn [msg]
-    (try
-      (result-handler msg (component-handler msg))
-      (catch Exception e
-        (error e (str "Consumer exception processing msg. Msg: " msg))))))
+    (result-handler msg (component-handler msg))))
 
 (s/def ::command-result
   (let [single-result (s/cat :event map?

--- a/test/kixi/comms/components/kafka_test.clj
+++ b/test/kixi/comms/components/kafka_test.clj
@@ -110,3 +110,8 @@
 
 (deftest kafka-command-produced-events-are-partitioned
   (all-tests/command-produced-events-are-partitioned(:kafka @system)))
+
+(comment "For kafka we wouldn't check for/want all Event processing to stop, just the specific handler"
+         (deftest kafka-exception-when-event-processing-stops-all-event-processing
+           (binding [*wait-per-try* long-wait]
+             (all-tests/exception-when-event-processing-stops-all-event-processing (:kinesis @system) opts))))


### PR DESCRIPTION
Previously we continued processing on unexpected exceptions, but its
clear now that this could lead to problems with our event aggregators.

This change removes catches from within the code and allows exceptions
to bubble up to the top level Kinesis processor function. This logs a
fatal level message, before triggering the worker that is wrapping it
to shutdown. This comms is handled via a dedicated core.async channel.

This should leave the rest of any service using the library able to
handle query requests and the other processor be that for events or
commands. It is expected that Kinesis, upon seeing this processor
shutdown, will allocate the current shards over to other processors,
causing them to fail as well.

Alerts have been configured for all fatal level messages, and the
message will include the offending Kinesis record data. It is expected
that some kind of manual fix will be required and then the service
will need to be restarted.