### PR TITLE
Remove code which tampers with event results

### DIFF
--- a/src/kixi/comms/messages.clj
+++ b/src/kixi/comms/messages.clj
@@ -192,7 +192,6 @@
                                          (event-result->commands result))]
           (validate-commands event conformed-result)
           (doseq [{:keys [cmd opts]} conformed-result]
-            (println "OMG WE ARE SENDING THIS" cmd)
             (comms/send-valid-command! comms-component
                                        cmd
                                        opts)))))))

--- a/src/kixi/comms/messages.clj
+++ b/src/kixi/comms/messages.clj
@@ -163,9 +163,7 @@
       (when-not (allowed-cmd-types ((juxt ::cmd/type ::cmd/version) cmd))
         (throw (ex-info "Invalid event result" {:allowed-command-types allowed-cmd-types
                                                 :event-type ((juxt ::event/type ::event/version) event)
-                                                :returned-command-type ((juxt ::cmd/type ::cmd/version) cmd)})))
-      (when-not (s/valid? :kixi/command cmd)
-        (throw (ex-info "Invalid command" (s/explain-data :kixi/command cmd)))))))
+                                                :returned-command-type ((juxt ::cmd/type ::cmd/version) cmd)}))))))
 
 (defn event-result->commands
   [result]
@@ -181,10 +179,7 @@
             (merge command
                    (select-keys event
                                 [:kixi/user
-                                 ::event/id])
-                   {:kixi.message/type :command
-                    ::cmd/id (uuid)
-                    ::cmd/created-at (comms/timestamp)}))))
+                                 ::event/id])))))
 
 (defn event-handler
   [comms-component service-event-handler]
@@ -197,6 +192,7 @@
                                          (event-result->commands result))]
           (validate-commands event conformed-result)
           (doseq [{:keys [cmd opts]} conformed-result]
+            (println "OMG WE ARE SENDING THIS" cmd)
             (comms/send-valid-command! comms-component
                                        cmd
                                        opts)))))))


### PR DESCRIPTION
**Remove code which tampers with event results**
We don't need this code because event results (commands) are sent
using `send-valid-command!` which both adds command map
boilerplate (id, type etc) and calls `s/valid?`. The removed code
actually forced a random UUID which shouldn't happen if an ID is
provided; `send-valid-command!` does this properly already