### PR TITLE
Improve the performance of generating messages

### DIFF
--- a/src/kixi/comms.clj
+++ b/src/kixi/comms.clj
@@ -1,5 +1,6 @@
 (ns kixi.comms
   (:require [clojure.spec.alpha :as s]
+            [clojure.spec.gen.alpha :as gen]
             [com.gfredericks.schpec :as sh]
             [clj-time.core :as time]
             [clj-time.format :as tf]

--- a/src/kixi/comms.clj
+++ b/src/kixi/comms.clj
@@ -71,8 +71,9 @@
 (s/def :kixi/command
   (s/and
    (s/merge ::command/payload
-            (s/keys :req [::msg/type
-                          ::command/id
+            (s/keys :req [::msg/type]
+                    :gen #(gen/return {::msg/type :command}))
+            (s/keys :req [::command/id
                           ::command/type
                           ::command/version
                           ::command/created-at
@@ -113,8 +114,9 @@
 (s/def :kixi/event
   (s/and
    (s/merge ::event/payload
-            (s/keys :req [::msg/type
-                          ::event/type
+            (s/keys :req [::msg/type]
+                    :gen #(gen/return {::msg/type :event}))
+            (s/keys :req [::event/type
                           ::event/version
                           ::event/created-at
                           ::event/id


### PR DESCRIPTION
**Improve the performance of generating messages**
Both `:kixi/event` and `:kixi/command` combined `::msg/type` with an
`s/and` and predicate to ensure the correct value (`:event` or
`:command` respectively). We've added an explicit generator now which
should increase the performance of generating events or commands